### PR TITLE
fix: change type from int to float64

### DIFF
--- a/integrations_and_orders.go
+++ b/integrations_and_orders.go
@@ -185,8 +185,8 @@ type InsertingShipmentsParcelStatusWebhookReturn struct {
 		CustomsDeclaration struct {
 		} `json:"customs_declaration"`
 		OrderNumber         string      `json:"order_number"`
-		InsuredValue        int         `json:"insured_value"`
-		TotalInsuredValue   int         `json:"total_insured_value"`
+		InsuredValue        float64     `json:"insured_value"`
+		TotalInsuredValue   float64     `json:"total_insured_value"`
 		ToState             interface{} `json:"to_state"`
 		CustomsInvoiceNr    string      `json:"customs_invoice_nr"`
 		CustomsShipmentType interface{} `json:"customs_shipment_type"`


### PR DESCRIPTION
Changes insured value fields to float64 in Go backend to improve precision in handling monetary values.
